### PR TITLE
Add missing dependency in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ You have to install the following dependencies:
   - OpenGL for Python (python-opengl)
   - QtOpenGL for Python (python-qt4-gl)
   - shapely
+  - sphinx (python-sphinx)
   - pytest, hypothesis and mock (for running tests only)
 
 Clone the repo in a `albion` directory. Add the directory containing `albion` to your PYTHONPATH environment variable.


### PR DESCRIPTION
This commit documents sphinx as a dependency.

Without sphinx installed, the installation process as documented yield the
following error:

```
Traceback (most recent call last):
  File "/usr/lib/python2.7/runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/home/augustin/workspace/albion/package.py", line 98, in <module>
    build_doc()
  File "albion/doc/__init__.py", line 36, in build
    exec_cmd(cmd)
  File "albion/doc/__init__.py", line 20, in exec_cmd
    stderr=PIPE, stdout=PIPE).communicate()
  File "/usr/lib/python2.7/subprocess.py", line 711, in __init__
    errread, errwrite)
  File "/usr/lib/python2.7/subprocess.py", line 1343, in _execute_child
    raise child_exception
OSError: [Errno 2] No such file or directory
```

@vmora what do you think? thanks!