### PR TITLE
Add a button to refresh diagraphy

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -149,6 +149,10 @@ class Plugin(QObject):
                 self.project is not None and self.project.has_cell,
                 "Refresh materialized view of all cell edges used by graph possible edges.")
 
+        self.__add_menu_entry('Refresh diagraphy', self.__refresh_diagraphy,
+                self.project is not None,
+                "Refresh materialized view of radiometry and resistivity.")
+
         self.__menu.addSeparator()
 
         #self.__add_menu_entry(u'Create section views 0° and 90°', self.__create_section_view_0_90,
@@ -219,6 +223,10 @@ class Plugin(QObject):
             return
         self.project.refresh_all_edge()
 
+    def __refresh_diagraphy(self):
+        if self.project:
+            self.project.refresh_radiometry()
+            self.project.refresh_resistivity()
 
     def __create_terminations(self):
         if self.project is None:

--- a/project.py
+++ b/project.py
@@ -318,6 +318,18 @@ class Project(object):
             cur.execute("refresh materialized view albion.all_edge")
             con.commit()
 
+    def refresh_radiometry(self):
+        with self.connect() as con:
+            cur = con.cursor()
+            cur.execute("refresh materialized view albion.radiometry_section")
+            con.commit()
+
+    def refresh_resistivity(self):
+        with self.connect() as con:
+            cur = con.cursor()
+            cur.execute("refresh materialized view albion.resistivity_section")
+            con.commit()
+
     def create_sections(self):
         with self.connect() as con:
             cur = con.cursor()


### PR DESCRIPTION
Fixes #58 by adding a new button to refresh materialized views `albion.radiometry_section` and `albion.resistivity_section`:

![p](https://user-images.githubusercontent.com/9266424/50600873-6435fe00-0eaa-11e9-9982-95b6816ca735.png)
