### PR TITLE
Add export elementary volume feature

### DIFF
--- a/export_elementary_volume.py
+++ b/export_elementary_volume.py
@@ -1,0 +1,64 @@
+import os
+
+from PyQt4 import uic
+from PyQt4.QtGui import QDialog, QFileDialog
+
+from qgis.core import QgsFeatureRequest
+
+
+FORM_CLASS, _ = uic.loadUiType(
+    os.path.join(os.path.dirname(__file__), "export_elementary_volume.ui")
+)
+
+
+class ExportElementaryVolume(QDialog, FORM_CLASS):
+    def __init__(self, layer, project, parent=None):
+        super(ExportElementaryVolume, self).__init__(parent)
+        self.setupUi(self)
+
+        self.cell_layer = layer
+        self.project = project
+
+        self.mSelect.clicked.connect(self.__select)
+        self.mButtonBox.accepted.connect(self.__export)
+
+    def __select(self):
+        dlg = QFileDialog()
+        dlg.setFileMode(QFileDialog.Directory)
+
+        filenames = []
+        if dlg.exec_():
+            filenames = dlg.selectedFiles()
+
+        if filenames:
+            filename = filenames[0]
+            self.mOutputDir.setText(filename)
+
+    def __export(self):
+
+        fids = self.cell_layer.allFeatureIds()
+        if self.mSelection.isChecked():
+            fids = self.cell_layer.selectedFeaturesIds()
+
+        for fid in fids:
+            request = QgsFeatureRequest(fid)
+
+            ft = None
+            for feature in self.cell_layer.getFeatures(request):
+                ft = feature
+
+            if not ft:
+                return
+
+            cell = ft["id"]
+            cell_dir = os.path.join(self.mOutputDir.text(), "{}".format(cell))
+            os.makedirs(cell_dir)
+
+            for graph in self.project.graphs():
+
+                if self.mFormat.currentText() == "OBJ":
+                    self.project.export_elementary_volume_obj(graph, cell, cell_dir)
+                else: # DXF
+                    self.project.export_elementary_volume_dxf(graph, cell, cell_dir)
+
+        # mFormat

--- a/export_elementary_volume.py
+++ b/export_elementary_volume.py
@@ -1,7 +1,8 @@
 import os
 
 from PyQt4 import uic
-from PyQt4.QtGui import QDialog, QFileDialog
+from PyQt4.QtCore import Qt
+from PyQt4.QtGui import QDialog, QFileDialog, QApplication, QCursor
 
 from qgis.core import QgsFeatureRequest
 
@@ -40,6 +41,10 @@ class ExportElementaryVolume(QDialog, FORM_CLASS):
         if self.mSelection.isChecked():
             fids = self.cell_layer.selectedFeaturesIds()
 
+        closed = self.mClosedVolume.isChecked()
+
+        QApplication.setOverrideCursor(QCursor(Qt.WaitCursor))
+        QApplication.processEvents()
         for fid in fids:
             request = QgsFeatureRequest(fid)
 
@@ -57,8 +62,11 @@ class ExportElementaryVolume(QDialog, FORM_CLASS):
             for graph in self.project.graphs():
 
                 if self.mFormat.currentText() == "OBJ":
-                    self.project.export_elementary_volume_obj(graph, cell, cell_dir)
-                else: # DXF
-                    self.project.export_elementary_volume_dxf(graph, cell, cell_dir)
-
-        # mFormat
+                    self.project.export_elementary_volume_obj(
+                        graph, cell, cell_dir, closed
+                    )
+                else:  # DXF
+                    self.project.export_elementary_volume_dxf(
+                        graph, cell, cell_dir, closed
+                    )
+        QApplication.restoreOverrideCursor()

--- a/export_elementary_volume.ui
+++ b/export_elementary_volume.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>141</height>
+    <height>170</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,7 +17,7 @@
    <property name="geometry">
     <rect>
      <x>40</x>
-     <y>100</y>
+     <y>130</y>
      <width>341</width>
      <height>32</height>
     </rect>
@@ -35,10 +35,23 @@
      <x>10</x>
      <y>10</y>
      <width>371</width>
-     <height>81</height>
+     <height>109</height>
     </rect>
    </property>
    <layout class="QFormLayout" name="formLayout_2">
+    <property name="fieldGrowthPolicy">
+     <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+    </property>
+    <item row="1" column="0">
+     <widget class="QLineEdit" name="mOutputDir"/>
+    </item>
+    <item row="1" column="1">
+     <widget class="QPushButton" name="mSelect">
+      <property name="text">
+       <string>Select</string>
+      </property>
+     </widget>
+    </item>
     <item row="2" column="0">
      <widget class="QLabel" name="label_3">
       <property name="text">
@@ -74,13 +87,17 @@
       </property>
      </widget>
     </item>
-    <item row="1" column="0">
-     <widget class="QLineEdit" name="mOutputDir"/>
-    </item>
-    <item row="1" column="1">
-     <widget class="QPushButton" name="mSelect">
+    <item row="4" column="0">
+     <widget class="QLabel" name="label">
       <property name="text">
-       <string>Select</string>
+       <string>Export closed volume only</string>
+      </property>
+     </widget>
+    </item>
+    <item row="4" column="1">
+     <widget class="QCheckBox" name="mClosedVolume">
+      <property name="text">
+       <string/>
       </property>
      </widget>
     </item>

--- a/export_elementary_volume.ui
+++ b/export_elementary_volume.ui
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Dialog</class>
+ <widget class="QDialog" name="Dialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>141</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <widget class="QDialogButtonBox" name="mButtonBox">
+   <property name="geometry">
+    <rect>
+     <x>40</x>
+     <y>100</y>
+     <width>341</width>
+     <height>32</height>
+    </rect>
+   </property>
+   <property name="orientation">
+    <enum>Qt::Horizontal</enum>
+   </property>
+   <property name="standardButtons">
+    <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+   </property>
+  </widget>
+  <widget class="QWidget" name="formLayoutWidget_2">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>10</y>
+     <width>371</width>
+     <height>81</height>
+    </rect>
+   </property>
+   <layout class="QFormLayout" name="formLayout_2">
+    <item row="2" column="0">
+     <widget class="QLabel" name="label_3">
+      <property name="text">
+       <string>Format</string>
+      </property>
+     </widget>
+    </item>
+    <item row="2" column="1">
+     <widget class="QComboBox" name="mFormat">
+      <item>
+       <property name="text">
+        <string>DXF</string>
+       </property>
+      </item>
+      <item>
+       <property name="text">
+        <string>OBJ</string>
+       </property>
+      </item>
+     </widget>
+    </item>
+    <item row="3" column="0">
+     <widget class="QLabel" name="label_2">
+      <property name="text">
+       <string>Export selection only</string>
+      </property>
+     </widget>
+    </item>
+    <item row="3" column="1">
+     <widget class="QCheckBox" name="mSelection">
+      <property name="text">
+       <string/>
+      </property>
+     </widget>
+    </item>
+    <item row="1" column="0">
+     <widget class="QLineEdit" name="mOutputDir"/>
+    </item>
+    <item row="1" column="1">
+     <widget class="QPushButton" name="mSelect">
+      <property name="text">
+       <string>Select</string>
+      </property>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>mButtonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>Dialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>mButtonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>Dialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/plugin.py
+++ b/plugin.py
@@ -610,7 +610,7 @@ class Plugin(QObject):
         if not fil:
             return
 
-        QgsProject.instance().writeEntry("albion", "last_dir", os.path.dirname(fil)),
+        QgsProject.instance().writeEntry("albion", "last_dir", os.path.dirname(fil))
 
         if fil[-4:] == ".obj":
             self.project.export_obj(self.__current_graph.currentText(), fil)

--- a/plugin.py
+++ b/plugin.py
@@ -34,6 +34,8 @@ from .viewer_3d.viewer_3d import Viewer3d
 from .viewer_3d.viewer_controls import ViewerControls
 from .log_strati import BoreHoleWindow
 
+from .export_elementary_volume import ExportElementaryVolume
+
 from shapely.geometry import LineString
 import numpy
 import math
@@ -262,6 +264,13 @@ class Plugin(QObject):
             "Export volume of current graph in .obj or .dxf format",
         )
 
+        self.__add_menu_entry(
+            "Export Elementary Volume",
+            self.__export_elementary_volume,
+            self.project is not None and bool(self.__current_graph.currentText()),
+            "Export an elementary volume of current graph in .obj or .dxf format",
+        )
+
         self.__menu.addSeparator()
 
         self.__menu.addAction("Help").triggered.connect(self.open_help)
@@ -323,6 +332,15 @@ class Plugin(QObject):
         for layer in self.__iface.mapCanvas().layers():
             if name is None or layer.name().find(name) != -1:
                 layer.triggerRepaint()
+
+    def __layer(self, name):
+        lay = None
+
+        for layer in self.__iface.mapCanvas().layers():
+            if name is None or layer.name().find(name) != -1:
+                lay = layer
+
+        return lay
 
     def __current_section_changed(self, section_id):
         layers = QgsMapLayerRegistry.instance().mapLayersByName(u"group_cell")
@@ -602,6 +620,18 @@ class Plugin(QObject):
             self.__iface.messageBar().pushWarning(
                 "Albion", "unsupported extension for volume export"
             )
+
+    def __export_elementary_volume(self):
+        if self.project is None:
+            return
+
+        layer = self.__layer("cell")
+        if not layer:
+            return
+
+        export_widget = ExportElementaryVolume(layer, self.project)
+        export_widget.show()
+        export_widget.exec_()
 
     def __import_project(self):
         fil = QFileDialog.getOpenFileName(

--- a/project.py
+++ b/project.py
@@ -641,16 +641,19 @@ class Project(object):
             )
             open(filename, "w").write(cur.fetchone()[0])
 
-    def export_elementary_volume_obj(self, graph_id, cell_id, outdir):
+    def export_elementary_volume_obj(self, graph_id, cell_id, outdir, only_closed):
         with self.connect() as con:
+            closed = ""
+            if only_closed:
+                closed = "and albion.is_closed_volume(geom)"
+
             cur = con.cursor()
             cur.execute(
                 """
                 select albion.to_obj(geom) from albion.dynamic_volume
-                where cell_id='{}' and graph_id='{}'
-                and albion.is_closed_volume(geom)
+                where cell_id='{}' and graph_id='{}' {}
                 """.format(
-                    cell_id, graph_id
+                    cell_id, graph_id, closed
                 )
             )
 
@@ -661,16 +664,19 @@ class Project(object):
                 path = os.path.join(outdir, filename)
                 open(path, "w").write(obj[0])
 
-    def export_elementary_volume_dxf(self, graph_id, cell_id, outdir):
+    def export_elementary_volume_dxf(self, graph_id, cell_id, outdir, only_closed):
         with self.connect() as con:
+            closed = ""
+            if only_closed:
+                closed = "and albion.is_closed_volume(geom)"
+
             cur = con.cursor()
             cur.execute(
                 """
                 select geom from albion.dynamic_volume
-                where cell_id='{}' and graph_id='{}'
-                and albion.is_closed_volume(geom)
+                where cell_id='{}' and graph_id='{}' {}
                 """.format(
-                    cell_id, graph_id
+                    cell_id, graph_id, closed
                 )
             )
 

--- a/project.py
+++ b/project.py
@@ -641,6 +641,56 @@ class Project(object):
             )
             open(filename, "w").write(cur.fetchone()[0])
 
+    def export_elementary_volume_obj(self, graph_id, cell_id, outdir):
+        with self.connect() as con:
+            cur = con.cursor()
+            cur.execute(
+                """
+                select albion.to_obj(geom) from albion.dynamic_volume
+                where cell_id='{}' and graph_id='{}'
+                and albion.is_closed_volume(geom)
+                """.format(
+                    cell_id, graph_id
+                )
+            )
+
+            i = 0
+            for obj in cur.fetchall():
+                filename = '{}_{}.obj'.format(graph_id, i)
+                i += 1
+                path = os.path.join(outdir, filename)
+                open(path, "w").write(obj[0])
+
+    def export_elementary_volume_dxf(self, graph_id, cell_id, outdir):
+        with self.connect() as con:
+            cur = con.cursor()
+            cur.execute(
+                """
+                select geom from albion.dynamic_volume
+                where cell_id='{}' and graph_id='{}'
+                and albion.is_closed_volume(geom)
+                """.format(
+                    cell_id, graph_id
+                )
+            )
+
+            i = 0
+            for wkb_geom in cur.fetchall():
+                geom = wkb.loads(bytes.fromhex(wkb_geom[0]))
+
+                filename = '{}_{}.dxf'.format(graph_id, i)
+                path = os.path.join(outdir, filename)
+                drawing = dxf.drawing(path)
+
+                for p in geom:
+                    r = p.exterior.coords
+                    drawing.add(
+                        dxf.face3d([tuple(r[0]), tuple(r[1]), tuple(r[2])], flags=1)
+                    )
+                drawing.save()
+
+                i += 1
+
     def errors_obj(self, graph_id, filename):
         with self.connect() as con:
             cur = con.cursor()


### PR DESCRIPTION
This PR adds a new button allowing to export elementary volumes in DXF or OBJ. An output directory has to be selected where a sub-directory for each cell will be created. Then, each sub-directory will contain several `.dxf` or `.obj` files according to the number of graphs and closed elementary volumes within the corresponding cell.

Note that you may export a selection of cells instead of all elementary volumes. For exemple with the next selection:

![0](https://user-images.githubusercontent.com/9266424/51325077-1271a400-1a64-11e9-8aae-0295d17100bd.png)

we obtain these elementary volumes:

![1](https://user-images.githubusercontent.com/9266424/51325135-29b09180-1a64-11e9-9bb1-9ecd3c766b1a.png)

![3](https://user-images.githubusercontent.com/9266424/51325182-40ef7f00-1a64-11e9-8f05-24fffaa6c17b.png)

