### PR TITLE
Export elementary volume 2

### DIFF
--- a/export_elementary_volume.py
+++ b/export_elementary_volume.py
@@ -42,7 +42,7 @@ class ExportElementaryVolume(QDialog, FORM_CLASS):
         if self.mSelection.isChecked():
             fids = self.cell_layer.selectedFeaturesIds()
 
-        closed = self.mClosedVolume.isChecked()
+        closed_only = self.mClosedVolume.isChecked()
 
         QApplication.setOverrideCursor(QCursor(Qt.WaitCursor))
         QApplication.processEvents()
@@ -62,11 +62,21 @@ class ExportElementaryVolume(QDialog, FORM_CLASS):
 
             if self.mFormat.currentText() == "OBJ":
                 self.project.export_elementary_volume_obj(
-                    self.graph, cell, cell_dir, closed
+                    self.graph, cell, cell_dir, True
                 )
             else:  # DXF
                 self.project.export_elementary_volume_dxf(
-                    self.graph, cell, cell_dir, closed
+                    self.graph, cell, cell_dir, True
                 )
+
+            if not closed_only:
+                if self.mFormat.currentText() == "OBJ":
+                    self.project.export_elementary_volume_obj(
+                        self.graph, cell, cell_dir, False
+                    )
+                else:  # DXF
+                    self.project.export_elementary_volume_dxf(
+                        self.graph, cell, cell_dir, False
+                    )
 
         QApplication.restoreOverrideCursor()

--- a/export_elementary_volume.py
+++ b/export_elementary_volume.py
@@ -13,12 +13,13 @@ FORM_CLASS, _ = uic.loadUiType(
 
 
 class ExportElementaryVolume(QDialog, FORM_CLASS):
-    def __init__(self, layer, project, parent=None):
+    def __init__(self, layer, project, graph, parent=None):
         super(ExportElementaryVolume, self).__init__(parent)
         self.setupUi(self)
 
         self.cell_layer = layer
         self.project = project
+        self.graph = graph
 
         self.mSelect.clicked.connect(self.__select)
         self.mButtonBox.accepted.connect(self.__export)
@@ -59,14 +60,13 @@ class ExportElementaryVolume(QDialog, FORM_CLASS):
             cell_dir = os.path.join(self.mOutputDir.text(), "{}".format(cell))
             os.makedirs(cell_dir)
 
-            for graph in self.project.graphs():
+            if self.mFormat.currentText() == "OBJ":
+                self.project.export_elementary_volume_obj(
+                    self.graph, cell, cell_dir, closed
+                )
+            else:  # DXF
+                self.project.export_elementary_volume_dxf(
+                    self.graph, cell, cell_dir, closed
+                )
 
-                if self.mFormat.currentText() == "OBJ":
-                    self.project.export_elementary_volume_obj(
-                        graph, cell, cell_dir, closed
-                    )
-                else:  # DXF
-                    self.project.export_elementary_volume_dxf(
-                        graph, cell, cell_dir, closed
-                    )
         QApplication.restoreOverrideCursor()

--- a/plugin.py
+++ b/plugin.py
@@ -629,7 +629,8 @@ class Plugin(QObject):
         if not layer:
             return
 
-        export_widget = ExportElementaryVolume(layer, self.project)
+        graph = self.__current_graph.currentText()
+        export_widget = ExportElementaryVolume(layer, self.project, graph)
         export_widget.show()
         export_widget.exec_()
 


### PR DESCRIPTION
With this PR, elementary volumes are exported only for the current graph.

Moreover, filenames contains `opened` or `closed` according to their status.