### PR TITLE
Don't replace a space by an underscore in project name

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -443,7 +443,7 @@ class Plugin(QObject):
         if not fil:
             return
         fil = fil if len(fil) > 4 and fil[-4:] == ".qgs" else fil + ".qgs"
-        fil = fil.replace(" ", "_")
+        # fil = fil.replace(" ", "_")
         if len(fil) != len(fil.encode()):
             self.__iface.messageBar().pushError(
                 "Albion:", "project name may only contain asci character (no accent)"


### PR DESCRIPTION
A username can have a space (and other dirty char). For example "Mining college":

![image](https://user-images.githubusercontent.com/7521540/74923789-af261400-53d1-11ea-9658-97d8cd1ecd90.png)

@DUGUEY